### PR TITLE
Add vars argument to role dependencies

### DIFF
--- a/f/ansible-meta.json
+++ b/f/ansible-meta.json
@@ -269,6 +269,10 @@
           "title": "Role",
           "type": "string"
         },
+        "vars": {
+          "title": "Vars",
+          "type": "object"
+        },
         "scm": {
           "enum": [
             "hg",


### PR DESCRIPTION
According to https://docs.ansible.com/ansible/latest/user_guide/playbooks_reuse_roles.html#using-role-dependencies it is possible to pass vars via role dependencies.

Is it possible to add it to `ansible-meta.json` schema ? 