### PR TITLE
Add optional `issue_tracker_url` key

### DIFF
--- a/src/ansibleschemas/meta.py
+++ b/src/ansibleschemas/meta.py
@@ -46,6 +46,7 @@ class GalaxyInfoModel(BaseModel):
     author: Optional[str] = Field(regex=r"[a-z0-9][a-z0-9_]+", min_length=2)
     description: str
     company: str
+    issue_tracker_url: Optional[str]
     license: str
     min_ansible_version: str
     min_ansible_container_version: Optional[str]


### PR DESCRIPTION
Optional property for if the issue tracker for the role is not on GitHub:

Referenced in [Ansible Docs](https://galaxy.ansible.com/docs/contributing/creating_role.html#role-metadata) and created by default but commented in `ansible-galaxy init`.