### PR TITLE
feat: add tags argument to role dependencies

### DIFF
--- a/f/ansible-meta.json
+++ b/f/ansible-meta.json
@@ -285,6 +285,10 @@
           "title": "Vars",
           "type": "object"
         },
+        "tags":{
+          "title": "Tags",
+          "type": "array"
+        },
         "version": {
           "title": "Version",
           "type": "string"

--- a/src/ansibleschemas/meta.py
+++ b/src/ansibleschemas/meta.py
@@ -63,6 +63,7 @@ class DependencyModel(BaseModel):
     # name: Union[str, HttpUrl] = Field(regex=r"[a-z][a-z0-9_]+\.[a-z0-9][a-z0-9_]+", min_length=2)
     # ^ url or galaxy namespace.rolename
     vars: Optional[Mapping[str, Any]]
+    tags: Optional[List[str]]
     version: Optional[str]
     scm: Optional[Literal["hg", "git"]]
 


### PR DESCRIPTION
It extends #27.

Using tags for dependencies inside `meta/main.yml` is not well documented but according to https://github.com/ansible/ansible/issues/14525#issuecomment-185974125 and my own experience, adding tags on entire roles using dependencies is possible.