### PR TITLE
Allow string for ansible tags

### DIFF
--- a/examples/playbooks/run.yml
+++ b/examples/playbooks/run.yml
@@ -4,9 +4,13 @@
     - name: username
       prompt: What is your username?
       private: false
+      tags:
+        - foo
+        - bar
 
     - name: password
       prompt: What is your password?
+      tags: foo
 
 - name: foo
   import_playbook: included.yml

--- a/f/ansible-playbook.json
+++ b/f/ansible-playbook.json
@@ -16220,10 +16220,17 @@
           "type": "object"
         },
         "tags": {
-          "items": {
-            "type": "string"
-          },
-          "type": "array"
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          ]
         },
         "tempfile": {
           "type": "object"
@@ -16763,11 +16770,18 @@
           "type": "boolean"
         },
         "tags": {
-          "items": {
-            "type": "string"
-          },
-          "title": "Tags",
-          "type": "array"
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          ],
+          "title": "Tags"
         },
         "throttle": {
           "title": "Throttle",
@@ -16976,11 +16990,18 @@
           "type": "string"
         },
         "tags": {
-          "items": {
-            "type": "string"
-          },
-          "title": "Tags",
-          "type": "array"
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          ],
+          "title": "Tags"
         },
         "tasks": {
           "$ref": "#/definitions/TasksListModel"
@@ -17315,11 +17336,18 @@
           "type": "boolean"
         },
         "tags": {
-          "items": {
-            "type": "string"
-          },
-          "title": "Tags",
-          "type": "array"
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          ],
+          "title": "Tags"
         },
         "throttle": {
           "title": "Throttle",

--- a/f/ansible-tasks.json
+++ b/f/ansible-tasks.json
@@ -16219,10 +16219,17 @@
           "type": "object"
         },
         "tags": {
-          "items": {
-            "type": "string"
-          },
-          "type": "array"
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          ]
         },
         "tempfile": {
           "type": "object"
@@ -16762,11 +16769,18 @@
           "type": "boolean"
         },
         "tags": {
-          "items": {
-            "type": "string"
-          },
-          "title": "Tags",
-          "type": "array"
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          ],
+          "title": "Tags"
         },
         "throttle": {
           "title": "Throttle",
@@ -16946,11 +16960,18 @@
           "type": "boolean"
         },
         "tags": {
-          "items": {
-            "type": "string"
-          },
-          "title": "Tags",
-          "type": "array"
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          ],
+          "title": "Tags"
         },
         "throttle": {
           "title": "Throttle",

--- a/src/ansibleschemas/tasks.py
+++ b/src/ansibleschemas/tasks.py
@@ -38,7 +38,7 @@ class _SharedModel(BaseModel):
     port: Optional[int]
     remote_user: Optional[str]
     run_once: Optional[bool]
-    tags: Optional[List[str]]
+    tags: Optional[Union[str, List[str]]]
     throttle: Optional[int]
     timeout: Optional[int]
     vars: Optional[Mapping[str, Any]]

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,7 @@ isolated_build = true
 requires =
   setuptools >= 41.4.0
   pip >= 19.3.0
+  tox-extra >= 0.2.0
 skip_missing_interpreters = True
 
 [testenv]


### PR DESCRIPTION
Allow simple string for tags in addition of list of strings.

Also enables use of tox-extra in order to report an error if the repository is dirty after running the tests. This should protect
against accidents.

Closes: #74 