### PR TITLE
Set spdx licenses list to 3.13

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,7 @@ description =
 changedir = {toxinidir}
 commands =
   # if download fails we use in-repo copy
-  -wget -q --delete-after --timestamping -O data/licenses.json https://raw.githubusercontent.com/spdx/license-list-data/master/json/licenses.json
+  -wget -q --delete-after --timestamping -O data/licenses.json https://raw.githubusercontent.com/spdx/license-list-data/v3.13/json/licenses.json
   sh -c "ansible-doc --json -l >{toxinidir}/data/modules-name.json"
   sh -c "ansible-doc --metadata-dump >{toxinidir}/data/modules-meta.json"
   {envpython} -m ansibleschemas


### PR DESCRIPTION
In order to control what version of spdx licenses list is in use, set it
explicitly so no big updates occur when its master branch is updated.

Fix #89.