### PR TITLE
add missing property `pre_build_image` to MoleculePlatformModel

### DIFF
--- a/examples/molecule/default/molecule.yml
+++ b/examples/molecule/default/molecule.yml
@@ -34,6 +34,7 @@ platforms:
     groups:
       - ubi8
     image: ubi8/ubi-init
+    pre_build_image: true
     registry:
       url: registry.access.redhat.com
     dockerfile: Dockerfile

--- a/f/molecule.json
+++ b/f/molecule.json
@@ -179,6 +179,10 @@
           "title": "Pkg Extras",
           "type": "string"
         },
+        "pre_build_image": {
+          "title": "Pre Build Image",
+          "type": "boolean"
+        },
         "privileged": {
           "title": "Privileged",
           "type": "boolean"

--- a/src/ansibleschemas/molecule.py
+++ b/src/ansibleschemas/molecule.py
@@ -85,6 +85,7 @@ class MoleculePlatformModel(BaseModel):
     groups: Optional[List[str]]
     # container specific
     image: Optional[str]
+    pre_build_image: Optional[bool]
     registry: Optional[ContainerRegistryModel]
     dockerfile: Optional[str]
     volumes: Optional[List[str]]


### PR DESCRIPTION
The molecule schema is missing `pre_build_image`.

See: #83