### PR TITLE
use `all` instead of `any` for PlatformVersionsEnum

### DIFF
--- a/examples/roles/foo/meta/main.yml
+++ b/examples/roles/foo/meta/main.yml
@@ -7,4 +7,4 @@ galaxy_info:
   platforms:
     - name: Alpine
       versions:
-        - any
+        - all

--- a/f/ansible-meta.json
+++ b/f/ansible-meta.json
@@ -10,7 +10,7 @@
           "type": "string"
         },
         "versions": {
-          "default": "any",
+          "default": "all",
           "items": {
             "$ref": "#/definitions/AIXPlatformVersionsEnum"
           },
@@ -26,7 +26,7 @@
         "6.1",
         "7.1",
         "7.2",
-        "any"
+        "all"
       ],
       "title": "AIXPlatformVersionsEnum"
     },
@@ -38,7 +38,7 @@
           "type": "string"
         },
         "versions": {
-          "default": "any",
+          "default": "all",
           "items": {
             "$ref": "#/definitions/AlpinePlatformVersionsEnum"
           },
@@ -51,7 +51,7 @@
     "AlpinePlatformVersionsEnum": {
       "description": "An enumeration.",
       "enum": [
-        "any"
+        "all"
       ],
       "title": "AlpinePlatformVersionsEnum"
     },
@@ -63,7 +63,7 @@
           "type": "string"
         },
         "versions": {
-          "default": "any",
+          "default": "all",
           "items": {
             "$ref": "#/definitions/AmazonPlatformVersionsEnum"
           },
@@ -89,7 +89,7 @@
         "2017.12",
         "2018.03",
         "Candidate",
-        "any"
+        "all"
       ],
       "title": "AmazonPlatformVersionsEnum"
     },
@@ -101,7 +101,7 @@
           "type": "string"
         },
         "versions": {
-          "default": "any",
+          "default": "all",
           "items": {
             "$ref": "#/definitions/Amazon_Linux_2PlatformVersionsEnum"
           },
@@ -114,7 +114,7 @@
     "Amazon_Linux_2PlatformVersionsEnum": {
       "description": "An enumeration.",
       "enum": [
-        "any"
+        "all"
       ],
       "title": "Amazon Linux 2PlatformVersionsEnum"
     },
@@ -126,7 +126,7 @@
           "type": "string"
         },
         "versions": {
-          "default": "any",
+          "default": "all",
           "items": {
             "$ref": "#/definitions/ArchLinuxPlatformVersionsEnum"
           },
@@ -139,7 +139,7 @@
     "ArchLinuxPlatformVersionsEnum": {
       "description": "An enumeration.",
       "enum": [
-        "any"
+        "all"
       ],
       "title": "ArchLinuxPlatformVersionsEnum"
     },
@@ -151,7 +151,7 @@
           "type": "string"
         },
         "versions": {
-          "default": "any",
+          "default": "all",
           "items": {
             "$ref": "#/definitions/ClearLinuxPlatformVersionsEnum"
           },
@@ -164,7 +164,7 @@
     "ClearLinuxPlatformVersionsEnum": {
       "description": "An enumeration.",
       "enum": [
-        "any"
+        "all"
       ],
       "title": "ClearLinuxPlatformVersionsEnum"
     },
@@ -176,7 +176,7 @@
           "type": "string"
         },
         "versions": {
-          "default": "any",
+          "default": "all",
           "items": {
             "$ref": "#/definitions/CumulusPlatformVersionsEnum"
           },
@@ -196,7 +196,7 @@
         "3.3",
         "3.4",
         "3.5",
-        "any"
+        "all"
       ],
       "title": "CumulusPlatformVersionsEnum"
     },
@@ -208,7 +208,7 @@
           "type": "string"
         },
         "versions": {
-          "default": "any",
+          "default": "all",
           "items": {
             "$ref": "#/definitions/DebianPlatformVersionsEnum"
           },
@@ -230,7 +230,7 @@
         "squeeze",
         "stretch",
         "wheezy",
-        "any"
+        "all"
       ],
       "title": "DebianPlatformVersionsEnum"
     },
@@ -242,7 +242,7 @@
           "type": "string"
         },
         "versions": {
-          "default": "any",
+          "default": "all",
           "items": {
             "$ref": "#/definitions/DellOSPlatformVersionsEnum"
           },
@@ -258,7 +258,7 @@
         "10",
         "6",
         "9",
-        "any"
+        "all"
       ],
       "title": "DellOSPlatformVersionsEnum"
     },
@@ -311,7 +311,7 @@
           "type": "string"
         },
         "versions": {
-          "default": "any",
+          "default": "all",
           "items": {
             "$ref": "#/definitions/DevuanPlatformVersionsEnum"
           },
@@ -328,7 +328,7 @@
         "beowulf",
         "ceres",
         "jessie",
-        "any"
+        "all"
       ],
       "title": "DevuanPlatformVersionsEnum"
     },
@@ -340,7 +340,7 @@
           "type": "string"
         },
         "versions": {
-          "default": "any",
+          "default": "all",
           "items": {
             "$ref": "#/definitions/DragonFlyBSDPlatformVersionsEnum"
           },
@@ -355,7 +355,7 @@
       "enum": [
         "5.2",
         "5.4",
-        "any"
+        "all"
       ],
       "title": "DragonFlyBSDPlatformVersionsEnum"
     },
@@ -367,7 +367,7 @@
           "type": "string"
         },
         "versions": {
-          "default": "any",
+          "default": "all",
           "items": {
             "$ref": "#/definitions/ELPlatformVersionsEnum"
           },
@@ -384,7 +384,7 @@
         "6",
         "7",
         "8",
-        "any"
+        "all"
       ],
       "title": "ELPlatformVersionsEnum"
     },
@@ -396,7 +396,7 @@
           "type": "string"
         },
         "versions": {
-          "default": "any",
+          "default": "all",
           "items": {
             "$ref": "#/definitions/FedoraPlatformVersionsEnum"
           },
@@ -428,7 +428,7 @@
         "32",
         "33",
         "34",
-        "any"
+        "all"
       ],
       "title": "FedoraPlatformVersionsEnum"
     },
@@ -440,7 +440,7 @@
           "type": "string"
         },
         "versions": {
-          "default": "any",
+          "default": "all",
           "items": {
             "$ref": "#/definitions/FreeBSDPlatformVersionsEnum"
           },
@@ -473,7 +473,7 @@
         "9.1",
         "9.2",
         "9.3",
-        "any"
+        "all"
       ],
       "title": "FreeBSDPlatformVersionsEnum"
     },
@@ -671,7 +671,7 @@
           "type": "string"
         },
         "versions": {
-          "default": "any",
+          "default": "all",
           "items": {
             "$ref": "#/definitions/GenericBSDPlatformVersionsEnum"
           },
@@ -684,7 +684,7 @@
     "GenericBSDPlatformVersionsEnum": {
       "description": "An enumeration.",
       "enum": [
-        "any"
+        "all"
       ],
       "title": "GenericBSDPlatformVersionsEnum"
     },
@@ -696,7 +696,7 @@
           "type": "string"
         },
         "versions": {
-          "default": "any",
+          "default": "all",
           "items": {
             "$ref": "#/definitions/GenericLinuxPlatformVersionsEnum"
           },
@@ -709,7 +709,7 @@
     "GenericLinuxPlatformVersionsEnum": {
       "description": "An enumeration.",
       "enum": [
-        "any"
+        "all"
       ],
       "title": "GenericLinuxPlatformVersionsEnum"
     },
@@ -721,7 +721,7 @@
           "type": "string"
         },
         "versions": {
-          "default": "any",
+          "default": "all",
           "items": {
             "$ref": "#/definitions/GenericUNIXPlatformVersionsEnum"
           },
@@ -734,7 +734,7 @@
     "GenericUNIXPlatformVersionsEnum": {
       "description": "An enumeration.",
       "enum": [
-        "any"
+        "all"
       ],
       "title": "GenericUNIXPlatformVersionsEnum"
     },
@@ -746,7 +746,7 @@
           "type": "string"
         },
         "versions": {
-          "default": "any",
+          "default": "all",
           "items": {
             "$ref": "#/definitions/GentooPlatformVersionsEnum"
           },
@@ -759,7 +759,7 @@
     "GentooPlatformVersionsEnum": {
       "description": "An enumeration.",
       "enum": [
-        "any"
+        "all"
       ],
       "title": "GentooPlatformVersionsEnum"
     },
@@ -771,7 +771,7 @@
           "type": "string"
         },
         "versions": {
-          "default": "any",
+          "default": "all",
           "items": {
             "$ref": "#/definitions/HardenedBSDPlatformVersionsEnum"
           },
@@ -786,7 +786,7 @@
       "enum": [
         "10",
         "11",
-        "any"
+        "all"
       ],
       "title": "HardenedBSDPlatformVersionsEnum"
     },
@@ -798,7 +798,7 @@
           "type": "string"
         },
         "versions": {
-          "default": "any",
+          "default": "all",
           "items": {
             "$ref": "#/definitions/IOSPlatformVersionsEnum"
           },
@@ -811,7 +811,7 @@
     "IOSPlatformVersionsEnum": {
       "description": "An enumeration.",
       "enum": [
-        "any"
+        "all"
       ],
       "title": "IOSPlatformVersionsEnum"
     },
@@ -823,7 +823,7 @@
           "type": "string"
         },
         "versions": {
-          "default": "any",
+          "default": "all",
           "items": {
             "$ref": "#/definitions/JunosPlatformVersionsEnum"
           },
@@ -836,7 +836,7 @@
     "JunosPlatformVersionsEnum": {
       "description": "An enumeration.",
       "enum": [
-        "any"
+        "all"
       ],
       "title": "JunosPlatformVersionsEnum"
     },
@@ -848,7 +848,7 @@
           "type": "string"
         },
         "versions": {
-          "default": "any",
+          "default": "all",
           "items": {
             "$ref": "#/definitions/MacOSXPlatformVersionsEnum"
           },
@@ -870,7 +870,7 @@
         "10.7",
         "10.8",
         "10.9",
-        "any"
+        "all"
       ],
       "title": "MacOSXPlatformVersionsEnum"
     },
@@ -882,7 +882,7 @@
           "type": "string"
         },
         "versions": {
-          "default": "any",
+          "default": "all",
           "items": {
             "$ref": "#/definitions/NXOSPlatformVersionsEnum"
           },
@@ -895,7 +895,7 @@
     "NXOSPlatformVersionsEnum": {
       "description": "An enumeration.",
       "enum": [
-        "any"
+        "all"
       ],
       "title": "NXOSPlatformVersionsEnum"
     },
@@ -907,7 +907,7 @@
           "type": "string"
         },
         "versions": {
-          "default": "any",
+          "default": "all",
           "items": {
             "$ref": "#/definitions/OpenBSDPlatformVersionsEnum"
           },
@@ -932,7 +932,7 @@
         "6.5",
         "6.6",
         "6.7",
-        "any"
+        "all"
       ],
       "title": "OpenBSDPlatformVersionsEnum"
     },
@@ -944,7 +944,7 @@
           "type": "string"
         },
         "versions": {
-          "default": "any",
+          "default": "all",
           "items": {
             "$ref": "#/definitions/PAN-OSPlatformVersionsEnum"
           },
@@ -961,7 +961,7 @@
         "8.0",
         "8.1",
         "9.0",
-        "any"
+        "all"
       ],
       "title": "PAN-OSPlatformVersionsEnum"
     },
@@ -973,7 +973,7 @@
           "type": "string"
         },
         "versions": {
-          "default": "any",
+          "default": "all",
           "items": {
             "$ref": "#/definitions/SLESPlatformVersionsEnum"
           },
@@ -996,7 +996,7 @@
         "12",
         "12SP1",
         "15",
-        "any"
+        "all"
       ],
       "title": "SLESPlatformVersionsEnum"
     },
@@ -1008,7 +1008,7 @@
           "type": "string"
         },
         "versions": {
-          "default": "any",
+          "default": "all",
           "items": {
             "$ref": "#/definitions/SmartOSPlatformVersionsEnum"
           },
@@ -1021,7 +1021,7 @@
     "SmartOSPlatformVersionsEnum": {
       "description": "An enumeration.",
       "enum": [
-        "any"
+        "all"
       ],
       "title": "SmartOSPlatformVersionsEnum"
     },
@@ -1033,7 +1033,7 @@
           "type": "string"
         },
         "versions": {
-          "default": "any",
+          "default": "all",
           "items": {
             "$ref": "#/definitions/SolarisPlatformVersionsEnum"
           },
@@ -1051,7 +1051,7 @@
         "11.1",
         "11.2",
         "11.3",
-        "any"
+        "all"
       ],
       "title": "SolarisPlatformVersionsEnum"
     },
@@ -1063,7 +1063,7 @@
           "type": "string"
         },
         "versions": {
-          "default": "any",
+          "default": "all",
           "items": {
             "$ref": "#/definitions/SynologyPlatformVersionsEnum"
           },
@@ -1076,7 +1076,7 @@
     "SynologyPlatformVersionsEnum": {
       "description": "An enumeration.",
       "enum": [
-        "any"
+        "all"
       ],
       "title": "SynologyPlatformVersionsEnum"
     },
@@ -1088,7 +1088,7 @@
           "type": "string"
         },
         "versions": {
-          "default": "any",
+          "default": "all",
           "items": {
             "$ref": "#/definitions/TMOSPlatformVersionsEnum"
           },
@@ -1105,7 +1105,7 @@
         "13.0",
         "13.1",
         "14.0",
-        "any"
+        "all"
       ],
       "title": "TMOSPlatformVersionsEnum"
     },
@@ -1117,7 +1117,7 @@
           "type": "string"
         },
         "versions": {
-          "default": "any",
+          "default": "all",
           "items": {
             "$ref": "#/definitions/UbuntuPlatformVersionsEnum"
           },
@@ -1154,7 +1154,7 @@
         "xenial",
         "yakkety",
         "zesty",
-        "any"
+        "all"
       ],
       "title": "UbuntuPlatformVersionsEnum"
     },
@@ -1166,7 +1166,7 @@
           "type": "string"
         },
         "versions": {
-          "default": "any",
+          "default": "all",
           "items": {
             "$ref": "#/definitions/Void_LinuxPlatformVersionsEnum"
           },
@@ -1179,7 +1179,7 @@
     "Void_LinuxPlatformVersionsEnum": {
       "description": "An enumeration.",
       "enum": [
-        "any"
+        "all"
       ],
       "title": "Void LinuxPlatformVersionsEnum"
     },
@@ -1191,7 +1191,7 @@
           "type": "string"
         },
         "versions": {
-          "default": "any",
+          "default": "all",
           "items": {
             "$ref": "#/definitions/WindowsPlatformVersionsEnum"
           },
@@ -1211,7 +1211,7 @@
         "2012R2",
         "2016",
         "2019",
-        "any"
+        "all"
       ],
       "title": "WindowsPlatformVersionsEnum"
     },
@@ -1223,7 +1223,7 @@
           "type": "string"
         },
         "versions": {
-          "default": "any",
+          "default": "all",
           "items": {
             "$ref": "#/definitions/aosPlatformVersionsEnum"
           },
@@ -1236,7 +1236,7 @@
     "aosPlatformVersionsEnum": {
       "description": "An enumeration.",
       "enum": [
-        "any"
+        "all"
       ],
       "title": "aosPlatformVersionsEnum"
     },
@@ -1248,7 +1248,7 @@
           "type": "string"
         },
         "versions": {
-          "default": "any",
+          "default": "all",
           "items": {
             "$ref": "#/definitions/eosPlatformVersionsEnum"
           },
@@ -1261,7 +1261,7 @@
     "eosPlatformVersionsEnum": {
       "description": "An enumeration.",
       "enum": [
-        "any"
+        "all"
       ],
       "title": "eosPlatformVersionsEnum"
     },
@@ -1273,7 +1273,7 @@
           "type": "string"
         },
         "versions": {
-          "default": "any",
+          "default": "all",
           "items": {
             "$ref": "#/definitions/macOSPlatformVersionsEnum"
           },
@@ -1289,7 +1289,7 @@
         "Big-Sur",
         "High-Sierra",
         "Sierra",
-        "any"
+        "all"
       ],
       "title": "macOSPlatformVersionsEnum"
     },
@@ -1301,7 +1301,7 @@
           "type": "string"
         },
         "versions": {
-          "default": "any",
+          "default": "all",
           "items": {
             "$ref": "#/definitions/opensusePlatformVersionsEnum"
           },
@@ -1325,7 +1325,7 @@
         "42.1",
         "42.2",
         "42.3",
-        "any"
+        "all"
       ],
       "title": "opensusePlatformVersionsEnum"
     },
@@ -1337,7 +1337,7 @@
           "type": "string"
         },
         "versions": {
-          "default": "any",
+          "default": "all",
           "items": {
             "$ref": "#/definitions/os10PlatformVersionsEnum"
           },
@@ -1350,8 +1350,7 @@
     "os10PlatformVersionsEnum": {
       "description": "An enumeration.",
       "enum": [
-        "all",
-        "any"
+        "all"
       ],
       "title": "os10PlatformVersionsEnum"
     },
@@ -1363,7 +1362,7 @@
           "type": "string"
         },
         "versions": {
-          "default": "any",
+          "default": "all",
           "items": {
             "$ref": "#/definitions/vCenterPlatformVersionsEnum"
           },
@@ -1381,7 +1380,7 @@
         "6.5",
         "6.7",
         "7.0",
-        "any"
+        "all"
       ],
       "title": "vCenterPlatformVersionsEnum"
     },
@@ -1393,7 +1392,7 @@
           "type": "string"
         },
         "versions": {
-          "default": "any",
+          "default": "all",
           "items": {
             "$ref": "#/definitions/vSpherePlatformVersionsEnum"
           },
@@ -1411,7 +1410,7 @@
         "6.5",
         "6.7",
         "7.0",
-        "any"
+        "all"
       ],
       "title": "vSpherePlatformVersionsEnum"
     }

--- a/src/ansibleschemas/meta.py
+++ b/src/ansibleschemas/meta.py
@@ -24,16 +24,16 @@ for platform_name, platform_versions in GALAXY_PLATFORMS.items():
         raise RuntimeError("Platforms versions are supposed to be list of strings.")
 
     args = {v: v for v in platform_versions}
-    args['any'] = 'any'
+    args['all'] = 'all'
     versionsEnum = Enum(f"{platform_name}PlatformVersionsEnum", args)  # type: ignore
 
     kwargs['name'] = Field(platform_name, const=True)
-    kwargs['versions'] = Field("any")
+    kwargs['versions'] = Field("all")
 
     model = create_model(
         f"{platform_name}PlatformModel",
         name=(str, Field(platform_name, const=True)),
-        versions=(List[versionsEnum], "any"),
+        versions=(List[versionsEnum], "all"),
     )  # type: ignore
     model.update_forward_refs()
     all_platforms.append(model)


### PR DESCRIPTION
ansible-galaxy uses the value `all` when creating the initial meta/main.yml. And also reading the galaxy source suggests that `all` should be used and `any` isn't considered a valid value:

- https://github.com/ansible/galaxy/blob/5d5c9418a190d11f0653b6a7e506c324d922b781/galaxy/importer/loaders/role.py#L471
- https://github.com/ansible/galaxy/blob/5d5c9418a190d11f0653b6a7e506c324d922b781/galaxy/importer/loaders/role.py#L202


Fixes #81