### PR TITLE
make `company` optional for ansible-meta as galaxy source suggests

### DIFF
--- a/f/ansible-meta.json
+++ b/f/ansible-meta.json
@@ -654,7 +654,6 @@
       },
       "required": [
         "description",
-        "company",
         "license",
         "min_ansible_version",
         "platforms",

--- a/src/ansibleschemas/meta.py
+++ b/src/ansibleschemas/meta.py
@@ -45,7 +45,7 @@ class GalaxyInfoModel(BaseModel):
     role_name: Optional[str] = Field(regex=r"[a-z][a-z0-9_]+", min_length=2)
     author: Optional[str] = Field(regex=r"[a-z0-9][a-z0-9_]+", min_length=2)
     description: str
-    company: str
+    company: Optional[str]
     issue_tracker_url: Optional[str]
     license: str
     min_ansible_version: str


### PR DESCRIPTION
Looking at https://github.com/ansible/ansible/blob/d0de3d3dc2551ca57a3ef0d04807c3f98daa5d26/lib/ansible/cli/galaxy.py#L931 suggests that `company` should be optional for ansible-meta.

Fixes: #82