### PR TITLE
add optional `name` for scenario in molecule schema

### DIFF
--- a/examples/molecule/cluster/molecule.yml
+++ b/examples/molecule/cluster/molecule.yml
@@ -59,13 +59,13 @@ provisioner:
 scenario:
   name: cluster
   test_sequence:
-  - destroy
-  - create
-  - prepare
-  - converge
-  - check
-  - verify
-  - destroy
+    - destroy
+    - create
+    - prepare
+    - converge
+    - check
+    - verify
+    - destroy
 
 verifier:
   name: ansible

--- a/examples/molecule/cluster/molecule.yml
+++ b/examples/molecule/cluster/molecule.yml
@@ -1,0 +1,71 @@
+---
+dependency:
+  name: galaxy
+
+driver:
+  name: docker
+
+lint: |
+  set -e
+  yamllint -c molecule/yaml-lint.yml .
+  ansible-lint
+  flake8
+
+platforms:
+  - name: instance-1
+    image: "geerlingguy/docker-${MOLECULE_DISTRO:-centos7}-ansible:latest"
+    command: ${MOLECULE_DOCKER_COMMAND:-""}
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    privileged: true
+    pre_build_image: true
+    groups:
+      - zookeeper
+
+  - name: instance-2
+    image: "geerlingguy/docker-${MOLECULE_DISTRO:-centos7}-ansible:latest"
+    command: ${MOLECULE_DOCKER_COMMAND:-""}
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    privileged: true
+    pre_build_image: true
+    groups:
+      - zookeeper
+
+  - name: instance-3
+    image: "geerlingguy/docker-${MOLECULE_DISTRO:-centos7}-ansible:latest"
+    command: ${MOLECULE_DOCKER_COMMAND:-""}
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    privileged: true
+    pre_build_image: true
+    groups:
+      - zookeeper
+
+provisioner:
+  name: ansible
+  log: false
+  playbooks:
+    converge: ${MOLECULE_PLAYBOOK:-converge.yml}
+  inventory:
+    host_vars:
+      instance-1:
+        zookeeper_id: 0
+      instance-2:
+        zookeeper_id: 1
+      instance-3:
+        zookeeper_id: 2
+
+scenario:
+  name: cluster
+  test_sequence:
+  - destroy
+  - create
+  - prepare
+  - converge
+  - check
+  - verify
+  - destroy
+
+verifier:
+  name: ansible

--- a/examples/molecule/default/molecule.yml
+++ b/examples/molecule/default/molecule.yml
@@ -100,7 +100,6 @@ provisioner:
       fact_caching_connection: /tmp/molecule/facts
 
 scenario:
-  # name: optional_name -- removed!
   test_sequence:
     - destroy
     - create

--- a/f/molecule.json
+++ b/f/molecule.json
@@ -225,6 +225,56 @@
       "title": "MoleculePlatformModel",
       "type": "object"
     },
+    "MoleculeScenarioModel": {
+      "additionalProperties": false,
+      "properties": {
+        "check_sequence": {
+          "$ref": "#/definitions/ScenarioSequence"
+        },
+        "cleanup_sequence": {
+          "$ref": "#/definitions/ScenarioSequence"
+        },
+        "converge_sequence": {
+          "$ref": "#/definitions/ScenarioSequence"
+        },
+        "create_sequence": {
+          "$ref": "#/definitions/ScenarioSequence"
+        },
+        "dependency_sequence": {
+          "$ref": "#/definitions/ScenarioSequence"
+        },
+        "destroy_sequence": {
+          "$ref": "#/definitions/ScenarioSequence"
+        },
+        "idempotence_sequence": {
+          "$ref": "#/definitions/ScenarioSequence"
+        },
+        "lint_sequence": {
+          "$ref": "#/definitions/ScenarioSequence"
+        },
+        "name": {
+          "title": "Name",
+          "type": "string"
+        },
+        "prepare_sequence": {
+          "$ref": "#/definitions/ScenarioSequence"
+        },
+        "side_effect_sequence": {
+          "$ref": "#/definitions/ScenarioSequence"
+        },
+        "syntax_sequence": {
+          "$ref": "#/definitions/ScenarioSequence"
+        },
+        "test_sequence": {
+          "$ref": "#/definitions/ScenarioSequence"
+        },
+        "verify_sequence": {
+          "$ref": "#/definitions/ScenarioSequence"
+        }
+      },
+      "title": "MoleculeScenarioModel",
+      "type": "object"
+    },
     "ProvisionerConfigOptionsDefaultsModel": {
       "additionalProperties": false,
       "properties": {
@@ -339,6 +389,29 @@
       "title": "ProvisionerModel",
       "type": "object"
     },
+    "ScenarioSequence": {
+      "additionalProperties": false,
+      "items": {
+        "enum": [
+          "check",
+          "cleanup",
+          "converge",
+          "create",
+          "dependency",
+          "destroy",
+          "idempotence",
+          "lint",
+          "prepare",
+          "side_effect",
+          "syntax",
+          "test",
+          "verify"
+        ],
+        "type": "string"
+      },
+      "title": "ScenarioSequence",
+      "type": "array"
+    },
     "VerifierModel": {
       "additionalProperties": false,
       "properties": {
@@ -388,29 +461,7 @@
       "$ref": "#/definitions/ProvisionerModel"
     },
     "scenario": {
-      "additionalProperties": {
-        "items": {
-          "enum": [
-            "check",
-            "cleanup",
-            "converge",
-            "create",
-            "dependency",
-            "destroy",
-            "idempotence",
-            "lint",
-            "prepare",
-            "side_effect",
-            "syntax",
-            "test",
-            "verify"
-          ],
-          "type": "string"
-        },
-        "type": "array"
-      },
-      "title": "Scenario",
-      "type": "object"
+      "$ref": "#/definitions/MoleculeScenarioModel"
     },
     "verifier": {
       "$ref": "#/definitions/VerifierModel"

--- a/src/ansibleschemas/__main__.py
+++ b/src/ansibleschemas/__main__.py
@@ -14,7 +14,7 @@ from ansibleschemas.ansiblelint import AnsibleLintModel
 from ansibleschemas.api import ansible_modules
 from ansibleschemas.galaxy import GalaxyFileModel
 from ansibleschemas.meta import MetaModel
-from ansibleschemas.molecule import MoleculeScenarioModel
+from ansibleschemas.molecule import MoleculeModel
 from ansibleschemas.playbook import PlaybookFileModel
 from ansibleschemas.requirements import RequirementsFileModel
 from ansibleschemas.tasks import TasksListModel
@@ -120,7 +120,7 @@ def main() -> None:
         "ansible-lint": AnsibleLintModel,
         "galaxy": GalaxyFileModel,
         "meta": MetaModel,
-        "molecule": MoleculeScenarioModel,
+        "molecule": MoleculeModel,
         "playbook": PlaybookFileModel,
         "requirements": RequirementsFileModel,
         "tasks": TasksListModel,

--- a/src/ansibleschemas/molecule.py
+++ b/src/ansibleschemas/molecule.py
@@ -114,27 +114,28 @@ class MoleculePlatformModel(BaseModel):
     class Config:
         extra = Extra.forbid
 
+
 class MoleculeScenarioModel(BaseModel):
     name: Optional[str]
 
     class ScenarioSequence(BaseModel):
         __root__: List[
-                Literal[
-                    "check",
-                    "cleanup",
-                    "converge",
-                    "create",
-                    "dependency",
-                    "destroy",
-                    "idempotence",
-                    "lint",
-                    "prepare",
-                    "side_effect",
-                    "syntax",
-                    "test",
-                    "verify",
-                ]
+            Literal[
+                "check",
+                "cleanup",
+                "converge",
+                "create",
+                "dependency",
+                "destroy",
+                "idempotence",
+                "lint",
+                "prepare",
+                "side_effect",
+                "syntax",
+                "test",
+                "verify",
             ]
+        ]
 
         class Config:
             extra = Extra.forbid
@@ -152,9 +153,10 @@ class MoleculeScenarioModel(BaseModel):
     syntax_sequence: Optional[ScenarioSequence]
     test_sequence: Optional[ScenarioSequence]
     verify_sequence: Optional[ScenarioSequence]
-   
+
     class Config:
         extra = Extra.forbid
+
 
 class ProvisionerConfigOptionsModel(BaseModel):
     class ProvisionerConfigOptionsDefaultsModel(BaseModel):

--- a/src/ansibleschemas/molecule.py
+++ b/src/ansibleschemas/molecule.py
@@ -114,6 +114,47 @@ class MoleculePlatformModel(BaseModel):
     class Config:
         extra = Extra.forbid
 
+class MoleculeScenarioModel(BaseModel):
+    name: Optional[str]
+
+    class ScenarioSequence(BaseModel):
+        __root__: List[
+                Literal[
+                    "check",
+                    "cleanup",
+                    "converge",
+                    "create",
+                    "dependency",
+                    "destroy",
+                    "idempotence",
+                    "lint",
+                    "prepare",
+                    "side_effect",
+                    "syntax",
+                    "test",
+                    "verify",
+                ]
+            ]
+
+        class Config:
+            extra = Extra.forbid
+
+    check_sequence: Optional[ScenarioSequence]
+    cleanup_sequence: Optional[ScenarioSequence]
+    converge_sequence: Optional[ScenarioSequence]
+    create_sequence: Optional[ScenarioSequence]
+    dependency_sequence: Optional[ScenarioSequence]
+    destroy_sequence: Optional[ScenarioSequence]
+    idempotence_sequence: Optional[ScenarioSequence]
+    lint_sequence: Optional[ScenarioSequence]
+    prepare_sequence: Optional[ScenarioSequence]
+    side_effect_sequence: Optional[ScenarioSequence]
+    syntax_sequence: Optional[ScenarioSequence]
+    test_sequence: Optional[ScenarioSequence]
+    verify_sequence: Optional[ScenarioSequence]
+   
+    class Config:
+        extra = Extra.forbid
 
 class ProvisionerConfigOptionsModel(BaseModel):
     class ProvisionerConfigOptionsDefaultsModel(BaseModel):
@@ -171,49 +212,14 @@ class VerifierModel(BaseModel):
         extra = Extra.forbid
 
 
-class MoleculeScenarioModel(BaseModel):
+class MoleculeModel(BaseModel):
     log: Optional[bool] = Field(default=True)
     dependency: Optional[MoleculeDependencyModel]
     driver: MoleculeDriverModel
     lint: Optional[str]
     platforms: List[MoleculePlatformModel]
     provisioner: Optional[ProvisionerModel]
-    scenario: Optional[
-        Mapping[
-            Literal[
-                "check_sequence",
-                "cleanup_sequence",
-                "converge_sequence",
-                "create_sequence",
-                "dependency_sequence",
-                "destroy_sequence",
-                "idempotence_sequence",
-                "lint_sequence",
-                "prepare_sequence",
-                "side_effect_sequence",
-                "syntax_sequence",
-                "test_sequence",
-                "verify_sequence",
-            ],
-            List[
-                Literal[
-                    "check",
-                    "cleanup",
-                    "converge",
-                    "create",
-                    "dependency",
-                    "destroy",
-                    "idempotence",
-                    "lint",
-                    "prepare",
-                    "side_effect",
-                    "syntax",
-                    "test",
-                    "verify",
-                ]
-            ],
-        ]
-    ]
+    scenario: Optional[MoleculeScenarioModel]
     verifier: Optional[VerifierModel]
 
     class Config:


### PR DESCRIPTION
Looking at the molecule schema it suggests that `name` is optional, but
can be defined and should be given for non-default scenarios

See: https://github.com/ansible-community/molecule/blob/master/src/molecule/model/schema_v3.py


This also fixes the schema for sequence names. Before this commit, the following didn't make the linter scream:

```yaml
---
scenario:
  syntax_sequence22222:
    - cleanup
```

Now it should only allow the defined sequence names.