### PR TITLE
update dependencies for python and npm

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -66,6 +66,9 @@ install_requires =
   rich>=10.2.0
   typing-extensions; python_version < "3.8"
 
+  # remove for ruamel.yaml => 0.17.18. See for details: https://sourceforge.net/p/ruamel-yaml-clib/tickets/7/
+  ruamel.yaml.clib; python_version >= "3.10"
+
 [options.entry_points]
 console_scripts =
   ansible-schemas = ansibleschemas.__main__:main


### PR DESCRIPTION
Pin ruamel.yaml.clib as install dependency for python_version >= "3.10".
Should be removed for ruamel.yaml => 0.17.18.
See for details: https://sourceforge.net/p/ruamel-yaml-clib/tickets/7/

Fixes: #105

Also dumps all module documentation as the `requirements.txt` lock file was updated and the ansible version comes from there.

Signed-off-by: Daniel Ziegenberg <daniel@ziegenberg.at>