### PR TITLE
run github actions also on python 3.8 and 3.10

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -85,10 +85,10 @@ jobs:
     - name: >-
         Initialize tox envs
       run: |
-        echo "${{ matrix.PREFIX }} tox -e ${{ matrix.tox_env }} --notest --skip-missing-interpreters false -vv"
+        set -ex
         ${{ matrix.PREFIX }} tox -e ${{ matrix.tox_env }} --notest --skip-missing-interpreters false -vv
 
     - name: Test with tox -e ${{ matrix.tox_env }}
       run: |
-        echo "${{ matrix.PREFIX }} tox -e ${{ matrix.tox_env }}"
+        set -ex
         ${{ matrix.PREFIX }} tox -e ${{ matrix.tox_env }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,7 +35,7 @@ jobs:
     - run: npm test
   tox:
     name: >-
-      ${{ matrix.tox_env }}
+      ${{ matrix.toxenv }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -43,15 +43,19 @@ jobs:
         include:
         - python-version: 3.8
           os: ubuntu-20.04
-          tox_env: py38,lint
+          toxenv: py38
         - python-version: 3.9
           os: ubuntu-20.04
-          tox_env: py39,lint
+          toxenv: py39
         - python-version: '3.10'
           os: ubuntu-20.04
-          tox_env: py310,lint
+          toxenv: py310
+        - python-version: 3.8
+          os: ubuntu-20.04
+          toxenv: lint
     env:
       TOX_PARALLEL_NO_SPINNER: 1
+      TOXENV: ${{ matrix.toxenv }}
       FORCE_COLOR: 1
 
     steps:
@@ -82,13 +86,13 @@ jobs:
       run: >-
         python3 -m pip freeze --all
 
-    - name: >-
-        Initialize tox envs
+    - name: Initialize tox envs
       run: |
         set -ex
-        ${{ matrix.PREFIX }} tox -e ${{ matrix.tox_env }} --notest --skip-missing-interpreters false -vv
+        tox --notest --skip-missing-interpreters false -vv
 
-    - name: Test with tox -e ${{ matrix.tox_env }}
+    - name: >-
+        Test with tox -e ${{ matrix.toxenv }}
       run: |
         set -ex
-        ${{ matrix.PREFIX }} tox -e ${{ matrix.tox_env }}
+        tox

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,22 +40,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        os:
+        - ubuntu-20.04
         include:
         - python-version: 3.8
-          os: ubuntu-20.04
-          toxenv: py38
         - python-version: 3.9
-          os: ubuntu-20.04
-          toxenv: py39
         - python-version: '3.10'
-          os: ubuntu-20.04
-          toxenv: py310
         - python-version: 3.8
-          os: ubuntu-20.04
           toxenv: lint
     env:
       TOX_PARALLEL_NO_SPINNER: 1
-      TOXENV: ${{ matrix.toxenv }}
+      TOXENV: ${{ matrix.noxenv && matrix.toxenv || 'py' }}
       FORCE_COLOR: 1
 
     steps:
@@ -87,12 +82,10 @@ jobs:
         python3 -m pip freeze --all
 
     - name: Initialize tox envs
-      run: |
-        set -ex
-        tox --notest --skip-missing-interpreters false -vv
+      run: tox --notest --skip-missing-interpreters false -vv
 
     - name: >-
-        Test with tox -e ${{ matrix.toxenv }}
+        Test with tox
       run: |
         set -ex
         tox

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,17 +35,21 @@ jobs:
     - run: npm test
   tox:
     name: >-
-      ${{ matrix.env.TOXENV }}
+      ${{ matrix.tox_env }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        python-version:
-        - 3.8
-        os:
-        - ubuntu-20.04
-        env:
-        - TOXENV: py,lint
+        include:
+        - python-version: 3.8
+          os: ubuntu-20.04
+          tox_env: py38,lint
+        - python-version: 3.9
+          os: ubuntu-20.04
+          tox_env: py39,lint
+        - python-version: '3.10'
+          os: ubuntu-20.04
+          tox_env: py310,lint
     env:
       TOX_PARALLEL_NO_SPINNER: 1
       FORCE_COLOR: 1
@@ -80,11 +84,11 @@ jobs:
 
     - name: >-
         Initialize tox envs
-      run: >-
-        python3 -m tox --notest --skip-missing-interpreters false -vv
-      env: ${{ matrix.env }}
-
-    - name: Test with tox
       run: |
-        python3 -m tox
-      env: ${{ matrix.env }}
+        echo "${{ matrix.PREFIX }} tox -e ${{ matrix.tox_env }} --notest --skip-missing-interpreters false -vv"
+        ${{ matrix.PREFIX }} tox -e ${{ matrix.tox_env }} --notest --skip-missing-interpreters false -vv
+
+    - name: Test with tox -e ${{ matrix.tox_env }}
+      run: |
+        echo "${{ matrix.PREFIX }} tox -e ${{ matrix.tox_env }}"
+        ${{ matrix.PREFIX }} tox -e ${{ matrix.tox_env }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,10 +42,11 @@ jobs:
       matrix:
         os:
         - ubuntu-20.04
+        python-version:
+        - 3.8
+        - 3.9
+        - '3.10'
         include:
-        - python-version: 3.8
-        - python-version: 3.9
-        - python-version: '3.10'
         - python-version: 3.8
           toxenv: lint
     env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,7 +50,7 @@ jobs:
           toxenv: lint
     env:
       TOX_PARALLEL_NO_SPINNER: 1
-      TOXENV: ${{ matrix.noxenv && matrix.toxenv || 'py' }}
+      TOXENV: ${{ matrix.toxenv && matrix.toxenv || 'py' }}
       FORCE_COLOR: 1
 
     steps:

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,6 +29,7 @@ classifiers =
   Programming Language :: Python :: 3.6
   Programming Language :: Python :: 3.7
   Programming Language :: Python :: 3.8
+  Programming Language :: Python :: 3.9
   Programming Language :: Python :: 3.10
 
   Topic :: Software Development :: Quality Assurance

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,6 +29,7 @@ classifiers =
   Programming Language :: Python :: 3.6
   Programming Language :: Python :: 3.7
   Programming Language :: Python :: 3.8
+  Programming Language :: Python :: 3.10
 
   Topic :: Software Development :: Quality Assurance
   Topic :: Software Development :: Testing

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 minversion = 3.23.0
 # py is before lint because it can alter tracked files
-envlist = py{38,39,310},lint
+envlist = py,lint
 isolated_build = true
 requires =
   setuptools >= 41.4.0

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 minversion = 3.23.0
 # py is before lint because it can alter tracked files
-envlist = py,lint
+envlist = py{38,39,310},lint
 isolated_build = true
 requires =
   setuptools >= 41.4.0


### PR DESCRIPTION
extends:
- tox.ini to also include python 3.8 and python 3.10 
- GH actions to also test with python 3.8 and python 3.10

This will succeed once #106 is merged.