### PR TITLE
log ajv validation errors to console

### DIFF
--- a/src/schema.spec.ts
+++ b/src/schema.spec.ts
@@ -43,6 +43,7 @@ function lint(file: string): boolean {
       if (validator) {
         let target = yaml.load(fs.readFileSync(file, 'utf8'));
         result = (validator(target) ? !expect_fail : expect_fail);
+        if (!result) console.log(validator.errors)
       }
       break;
     }


### PR DESCRIPTION
When running `npm test` and the validation fails, it just tells:

```
AssertionError [ERR_ASSERTION]: Expected values to be strictly equal:
false !== true
 + expected - actual
 -false
 +true
 
 at Context.<anonymous> (src/schema.spec.ts:67:16)
 at processImmediate (node:internal/timers:464:21)
```
which is not very helpful and absolutely not specific why it failed.

With this commit it logs the `validator.errors` to console, this should be improved later.
