### PR TITLE
vscode setting black

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -19,5 +19,6 @@
         "./f/ansible-requirements.json": ["requirements.yml"],
         "./f/zuul.json": ["zuul.d/**/*.yml", "zuul.d/**/*.yaml"],
         "./f/ansible-playbook.json": ["playbooks/*.yml", "playbooks/*.yaml"]
-    }
+    },
+    "python.formatting.provider": "black"
 }

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # Schemas for Ansible, Zuul and Molecule
 
+[![tox](https://github.com/ansible-community/schemas/actions/workflows/test.yml/badge.svg)](https://github.com/ansible-community/schemas/actions/workflows/test.yml)
+[![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
+[![Repository License: MIT](https://img.shields.io/badge/license-MIT-brightgreen.svg)](LICENSE)
+
+## About Schemas for Ansible, Zuul and Molecule
+
 This project aims to generate JSON/YAML validation schemas for Ansible
 files such as playbooks, tasks, requirements, meta or vars and also for
 Zuul and Molecule configuration.


### PR DESCRIPTION
As this project uses black for python code formatting it makes sense to also set this as the default python formatting provider in vscode.

Also adds a number of badges:
 - tox status
 - code style
 - license