### PR TITLE
Fix CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,1 @@
-* @ssbarnea
-* @webknjaz
+* @ssbarnea @webknjaz


### PR DESCRIPTION
Apparently GHA does not join entries using the same key and only load the last entry.