### PR TITLE
Refactor src/schema.spec.ts

### DIFF
--- a/src/schema.spec.ts
+++ b/src/schema.spec.ts
@@ -1,13 +1,10 @@
 import * as assert from 'assert';
 import * as path from 'path';
 import Ajv from "ajv"
-import { ValidateFunction } from "ajv";
 import fs from 'fs';
 import minimatch from 'minimatch';
 import yaml from 'js-yaml';
 
-// https://github.com/ajv-validator/ajv/issues/1373
-// https://ajv.js.org/strict-mode.html#prevent-unexpected-validation
 const ajv = new Ajv({
   strictTypes: false,
   strict: false,
@@ -15,51 +12,39 @@ const ajv = new Ajv({
   allErrors: true  // https://github.com/ajv-validator/ajv/issues/1581#issuecomment-832211568
 });
 
-let globToValidatorMap: Map<string, ValidateFunction> = new Map();
-
+// load whitelist of all test file subjects schemas can reference
+const example_files = getAllFiles('./examples');
 
 // load all schemas
-fs.readdir("f/", function(err, files) {
-  const schemaFiles = files.filter(el => path.extname(el) === '.json')
-  schemaFiles.forEach(function (file) {
-    let schema_json = JSON.parse(fs.readFileSync(`f/${file}`, 'utf8'));
-    const validator = ajv.compile(schema_json);
-    if (schema_json.examples == undefined) {
-      console.error(`Schema file ${file} is missing an examples key that we need for documenting file matching patterns.`);
-      return process.exit(1);
-    }
-    schema_json['examples'].forEach(function(glob: string) {
-      globToValidatorMap.set(glob, validator);
+const schema_files = fs.readdirSync("f/").filter(el => path.extname(el) === '.json');
+console.log(`Schemas: ${schema_files}`);
+
+describe('schemas under f/', function () {
+  schema_files.forEach(schema_file => {
+      const schema_json = JSON.parse(fs.readFileSync(`f/${schema_file}`, 'utf8'));
+      const validator = ajv.compile(schema_json);
+      if (schema_json.examples == undefined) {
+        console.error(`Schema file ${schema_file} is missing an examples key that we need for documenting file matching patterns.`);
+        return process.exit(1);
+      }
+      describe(schema_file, function() {
+        getTestFiles(schema_json.examples).forEach(({ file: test_file, expect_fail }) => {
+          it(`linting ${test_file}`, function () {
+            const result = (validator(yaml.load(fs.readFileSync(test_file, 'utf8'))) ? !expect_fail : expect_fail);
+            if (!result) console.log(validator.errors)
+            assert.strictEqual(result, true);
+          });
+      });
     });
   });
-  console.log(`Schemas: ${schemaFiles}`)
-})
+});
 
-function lint(file: string): boolean {
-  let result = false;
-  let found = false;
-  let expect_fail = fs.existsSync(`${file}.fail`)
-  // determine which validator to use
-  for (let key of Array.from(globToValidatorMap.keys())) {
-    let pattern = `**/${key}`;
-    let match_result = minimatch.match([file], pattern);
-    if (match_result.length) {
-      let validator = globToValidatorMap.get(key);
-      if (validator) {
-        let target = yaml.load(fs.readFileSync(file, 'utf8'));
-        result = (validator(target) ? !expect_fail : expect_fail);
-        if (!result) console.log(validator.errors)
-      }
-      found = true;
-      break;
-    }
-  }
-  if (!found) {
-    console.error(`Failed to match file ${file} to a schema pattern.`)
-    result = false;
-  }
-
-  return result;
+// find all tests for each schema file
+function getTestFiles(globs: string[]): { file: string, expect_fail: boolean }[] {
+  const files = Array.from(new Set(globs
+    .map((glob: any) => minimatch.match(example_files, path.join('**', glob)))
+    .flat()));
+  return files.map(f => ({ file: f, expect_fail: fs.existsSync(`${f}.fail`) }));
 }
 
 function getAllFiles(dir: string): string[] {
@@ -69,14 +54,3 @@ function getAllFiles(dir: string): string[] {
     return isDirectory ? [...files, ...getAllFiles(name)] : [...files, name];
   }, []);
 }
-
-describe('add()', function () {
-  getAllFiles("examples").forEach(file => {
-    if (path.extname(file) === '.yml') {
-      it(`linting ${file}`, function () {
-        let res = lint(file);
-        assert.strictEqual(res, true);
-      });
-    };
-  });
-});


### PR DESCRIPTION
Refactor src/schema.spec.ts to reduce complexity, improve readability. Also removes *.yml filter on example test files (now finds *.yaml test files too - which just means 1 extra test case is found). Also adjusts the mocha test output to be slightly more verbose and easy to trace what's being tested. 

Why? I just came across this repo today, was reading the test file, found logic a little hard to follow, so refactored.