### PR TITLE
changed_when: allow conditional expression

### DIFF
--- a/f/ansible-tasks.json
+++ b/f/ansible-tasks.json
@@ -235,7 +235,7 @@
         },
         "changed_when": {
           "title": "Changed When",
-          "type": "boolean"
+          "type": ["string", "boolean"]
         },
         "check_mode": {
           "title": "Check Mode",


### PR DESCRIPTION
Similarly to `failed_when`, the `changed_when` keyword [accepts a conditional expression](https://docs.ansible.com/ansible/latest/reference_appendices/playbooks_keywords.html#task).
