### PR TITLE
Allow multiple handlers in notify

### DIFF
--- a/f/ansible-playbook.json
+++ b/f/ansible-playbook.json
@@ -743,7 +743,17 @@
         },
         "notify": {
           "title": "Notify",
-          "type": "string"
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          ]
         },
         "poll": {
           "title": "Poll",

--- a/f/ansible-tasks.json
+++ b/f/ansible-tasks.json
@@ -322,7 +322,17 @@
         },
         "notify": {
           "title": "Notify",
-          "type": "string"
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          ]
         },
         "poll": {
           "title": "Poll",

--- a/test/playbooks/tasks/notify.yml
+++ b/test/playbooks/tasks/notify.yml
@@ -1,0 +1,11 @@
+- name: notify single handler
+  ansible.builtin.debug:
+    msg: task with single handler
+  notify: handler1
+
+- name: notify multiple handlers
+  ansible.builtin.debug:
+    msg: task with multiple handlers
+  notify:
+    - handler1
+    - handler2


### PR DESCRIPTION
Allow multiple handlers in notify because notify parameter could contain
an array of handlers according to Ansible documentation.

Fixes: #184